### PR TITLE
updated installation code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ Lazerpay Official react-native sdk
 ## Installation
 
 ```sh
-npm install lazerpay-react-native
+yarn add lazerpay-react-native
 ```
 
 Also install `react-native-webview` because it's a dependency for this package. Here's a [link](https://github.com/react-native-webview/react-native-webview) to their docs.
+
+```sh
+yarn add react-native-webview
+```
 
 ## Usage
 


### PR DESCRIPTION
The React Native community frowns upon using npm in RN projects. Instead, yarn is preferred, so we need to change `npm install` to `yarn add`